### PR TITLE
Retain case sensitivity when generating simpleTypeText instances for enums

### DIFF
--- a/src/Text/XML/HaXml/Schema/PrettyHaskell.hs
+++ b/src/Text/XML/HaXml/Schema/PrettyHaskell.hs
@@ -362,7 +362,7 @@ ppHighLevelDecl nx (EnumSimpleType t is comm) =
                            <+> (ppUnqConId nx t <> text "_" <> ppXNameCap i)
     enumText  (i,_) = text "simpleTypeText"
                            <+> (ppUnqConId nx t <> text "_" <> ppXNameCap i)
-                           <+> text "= \"" <> ppXNameCap i <> text "\""
+                           <+> text "= \"" <> ppXName i <> text "\""
     ppXNameCap (XName (N (x:xs))) = text (toUpper x:xs)
     ppXNameCap (XName x)          = error ("should never hit this " ++ show x)
 


### PR DESCRIPTION
This fixes a bug where HaXml was generating code that looked like:
```
instance SimpleType DistributedVirtualPortgroupPortgroupType where
        acceptingParser
          = do literal "earlyBinding"
               return DistributedVirtualPortgroupPortgroupType_EarlyBinding
              `onFail`
              do literal "lateBinding"
                 return DistributedVirtualPortgroupPortgroupType_LateBinding
              `onFail`
              do literal "ephemeral"
                 return DistributedVirtualPortgroupPortgroupType_Ephemeral
        simpleTypeText
          DistributedVirtualPortgroupPortgroupType_EarlyBinding
          = "EarlyBinding"
        simpleTypeText DistributedVirtualPortgroupPortgroupType_LateBinding
          = "LateBinding"
        simpleTypeText DistributedVirtualPortgroupPortgroupType_Ephemeral
          = "Ephemeral"
```
Clearly this would never round trip parse correctly, and the root cause is a forced uppercase in the pretty printer for `simpleTypeText`